### PR TITLE
Update to LLVM 13

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1627231651,
-        "narHash": "sha256-wGN3bPaRyiLHX98+12UgaMUUieV04/y4Bi/TYHQX218=",
+        "lastModified": 1633204467,
+        "narHash": "sha256-wm8XlUZZrvBcnPjUZl4GsRHbuXuOs5WdPS+NkilmsYM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f027f8e38d926ffc925f4b9a7b1aa09cf2451ebc",
+        "rev": "18e178040a8c3278da222ff9f8f15b9d44f0e569",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        llvmPackages = pkgs.llvmPackages_12;
+        llvmPackages = pkgs.llvmPackages_13;
       in
       rec {
         packages = flake-utils.lib.flattenTree {


### PR DESCRIPTION
As of https://github.com/ziglang/zig/commit/dde0adcb363f3a3f306c0fc9eaec511cc3b74965, zig now uses LLVM 13.